### PR TITLE
ux(download): Improve Visibility of Download Links

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,10 @@
       .row-download {
         cursor: pointer;
       }
+
+      .row-download td:first-child:not(:hover) {
+        color: var(--bs-blue);
+      }
     </style>
     <title>LANDrop - Drop any files to any devices on your LAN</title>
   </head>


### PR DESCRIPTION
It’s not obvious that the download links are there currently, as they’re not highlighted in any way. This small change should improve it and make it easier for people to find them.